### PR TITLE
feat: golang map types unioned with possible 'null'

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -801,7 +801,8 @@ func (ts *Typescript) typescriptType(ty types.Type) (parsedType, error) {
 			return parsedType{}, xerrors.Errorf("simplify generics in map: %w", err)
 		}
 		parsed := parsedType{
-			Value:          RecordReference(keyType.Value, valueType.Value),
+			// Golang `map` can be marshaled to `null` in json.
+			Value:          bindings.Union(RecordReference(keyType.Value, valueType.Value), &bindings.Null{}),
 			TypeParameters: tp,
 			RaisedComments: append(keyType.RaisedComments, valueType.RaisedComments...),
 		}

--- a/convert_test.go
+++ b/convert_test.go
@@ -117,3 +117,27 @@ func TestGeneration(t *testing.T) {
 		})
 	}
 }
+
+func TestNotNullMaps(t *testing.T) {
+	gen, err := guts.NewGolangParser()
+	require.NoError(t, err, "new convert")
+
+	dir := filepath.Join(".", "testdata", "maps")
+	err = gen.IncludeGenerate("./" + dir)
+	require.NoErrorf(t, err, "include %q", dir)
+
+	gen.IncludeCustomDeclaration(config.StandardMappings())
+
+	ts, err := gen.ToTypescript()
+	require.NoError(t, err, "to typescript")
+
+	ts.ApplyMutations(
+		config.NotNullMaps,
+	)
+
+	output, err := ts.Serialize()
+	require.NoErrorf(t, err, "generate %q", dir)
+
+	// Not perfect, this asserts if the record is a nullable type.
+	require.Contains(t, output, "SimpleMap: Record<string, string>;", "no nullable Record")
+}

--- a/testdata/anyreference/anyreference.ts
+++ b/testdata/anyreference/anyreference.ts
@@ -2,7 +2,7 @@
 
 // From anyreference/anyreference.go
 export interface Example {
-    readonly Value: Record<string, string>;
+    readonly Value: Record<string, string> | null;
 }
 
 // From anyreference/anyreference.go

--- a/testdata/genericmap/genericmap.go
+++ b/testdata/genericmap/genericmap.go
@@ -17,12 +17,10 @@ type Custom interface {
 	Foo | Buzz
 }
 
-// Not yet supported
-//type FooBuzzMap[R Custom] struct {
-//	Something map[string]R `json:"something"`
-//}
+type FooBuzzMap[R Custom] struct {
+	Something map[string]R `json:"something"`
+}
 
-// Not yet supported
-//type FooBuzzAnonymousUnion[R Foo | Buzz] struct {
-//	Something []R `json:"something"`
-//}
+type FooBuzzAnonymousUnion[R Foo | Buzz] struct {
+	Something []R `json:"something"`
+}

--- a/testdata/genericmap/genericmap.ts
+++ b/testdata/genericmap/genericmap.ts
@@ -18,3 +18,13 @@ export interface Foo {
 export interface FooBuzz<R extends Custom> {
     readonly something: readonly R[];
 }
+
+// From codersdk/genericmap.go
+export interface FooBuzzAnonymousUnion<R extends Foo | Buzz> {
+    readonly something: readonly R[];
+}
+
+// From codersdk/genericmap.go
+export interface FooBuzzMap<R extends Custom> {
+    readonly something: Record<string, R> | null;
+}

--- a/testdata/maps/maps.ts
+++ b/testdata/maps/maps.ts
@@ -2,7 +2,7 @@
 
 // From maps/map.go
 export interface Bar<T extends any> {
-    readonly SimpleMap: Record<string, string>;
-    readonly NumberMap: Record<string, number>;
-    readonly GenericMap: Record<string, T>;
+    readonly SimpleMap: Record<string, string> | null;
+    readonly NumberMap: Record<string, number> | null;
+    readonly GenericMap: Record<string, T> | null;
 }


### PR DESCRIPTION
Golang `map[<key>]<value>` can be `null` in json. This change unions the Record type with `null`.
To revert to the previous behavior, use the mutation 'NotNullMaps'