### PR TITLE
feat: add support for `omitzero` tag

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -687,7 +687,8 @@ func (ts *Typescript) buildStruct(obj types.Object, st *types.Struct) (*bindings
 			if jsonTag.Name != "" {
 				tsField.Name = jsonTag.Name
 			}
-			if len(jsonTag.Options) > 0 && jsonTag.Options[0] == "omitempty" {
+			isOptional := jsonTag.HasOption("omitempty") || jsonTag.HasOption("omitzero")
+			if len(jsonTag.Options) > 0 && isOptional {
 				tsField.QuestionToken = true
 			}
 		}

--- a/testdata/nullable/nullable.go
+++ b/testdata/nullable/nullable.go
@@ -4,8 +4,10 @@ import "database/sql"
 
 type NullableFields struct {
 	OmitEmpty         string       `json:"omitEmpty,omitempty"`
+	OmitZero          string       `json:"omitZero,omitzero"`
 	Nullable          *string      `json:"nullable"`
 	NullableOmitEmpty *string      `json:"nullableOmitEmpty,omitempty"`
+	NullableOmitZero  *string      `json:"nullableOmitZero,omitzero"`
 	NullTime          sql.NullTime `json:"nullTime"`
 	SlicePointer      []*string    `json:"slicePointer"`
 }

--- a/testdata/nullable/nullable.ts
+++ b/testdata/nullable/nullable.ts
@@ -9,8 +9,10 @@ export interface EmptyFields {
 // From nullable/nullable.go
 export interface NullableFields {
     readonly omitEmpty?: string;
+    readonly omitZero?: string;
     readonly nullable: string | null;
     readonly nullableOmitEmpty?: string | null;
+    readonly nullableOmitZero?: string | null;
     readonly nullTime: string | null;
     readonly slicePointer: readonly (string)[];
 }


### PR DESCRIPTION
#26 

Should we rename ⁠`SimplifyOmitEmpty` (mutations.go) to something like ⁠`SimplifyOptional` ?
This would more accurately reflect its handling of both ⁠`omitempty` and the new ⁠`omitzero`.

Alternatively, we could introduce a new function `⁠SimplifyOptional`, and then alias or deprecate ⁠SimplifyOmitEmpty.
What are your thoughts on this?