### PR TITLE
fix: handle consts with references to external types

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -180,7 +180,11 @@ func (p *GoParser) ToTypescript() (*Typescript, error) {
 		if err != nil {
 			return nil, fmt.Errorf("node %q: %w", key, err)
 		}
-		typescript.typescriptNodes[key] = &newNode
+		if newNode.Node == nil {
+			delete(typescript.typescriptNodes, key)
+		} else {
+			typescript.typescriptNodes[key] = &newNode
+		}
 	}
 
 	return typescript, nil

--- a/node.go
+++ b/node.go
@@ -29,6 +29,11 @@ func (t typescriptNode) applyMutations() (typescriptNode, error) {
 
 func (t *typescriptNode) AddEnum(member *bindings.EnumMember) {
 	t.mutations = append(t.mutations, func(v bindings.Node) (bindings.Node, error) {
+		if v == nil {
+			// Just delete the enum if the reference type cannot be found.
+			return nil, nil
+		}
+
 		alias, ok := v.(*bindings.Alias)
 		if ok {
 			// Switch to an enum

--- a/testdata/enums/enums.go
+++ b/testdata/enums/enums.go
@@ -1,5 +1,7 @@
 package enums
 
+import "time"
+
 type (
 	EnumString    string
 	EnumSliceType []EnumString
@@ -26,3 +28,9 @@ const (
 	AudienceTenant Audience = "tenant"
 	AudienceTeam   Audience = "team"
 )
+
+// EmptyEnum references `time.Duration`, so the constant is considered an enum.
+// However, 'time.Duration' is not a referenced type, so the enum does not exist
+// in the output.
+// For now, this kind of constant is ignored.
+const EmptyEnum = 30 * time.Second


### PR DESCRIPTION
Consts to external types look like enums, but fail to generate.

Closes https://github.com/coder/guts/issues/34